### PR TITLE
Suggested grammar and wording changes, improved export limit Error Subcode

### DIFF
--- a/draft-sa-grow-maxprefix.xml
+++ b/draft-sa-grow-maxprefix.xml
@@ -69,7 +69,7 @@
 
         <abstract>
             <t>
-                This document describes mechanisms to limit the negative impact of <xref target="RFC7908">route leaks</xref> or resource exhaustion in BGP-4 <xref target="RFC4271" /> implementations.
+                This document describes mechanisms to limit the negative impact of <xref target="RFC7908">route leaks</xref> and/or resource exhaustion in BGP-4 <xref target="RFC4271" /> implementations.
             </t>
         </abstract>
         <note title="Requirements Language">
@@ -81,7 +81,7 @@
     <middle>
         <section title="Introduction">
             <t>
-                This document describes mechanisms to reduce the negative impact of certain types of misconfigurations or resource exhaustions in BGP-4 <xref target="RFC4271" /> operations.
+                This document describes mechanisms to reduce the negative impact of certain types of misconfigurations and/or resource exhaustions in BGP-4 <xref target="RFC4271" /> operations.
                 While <xref target="RFC4271" /> already described a method to tear down BGP-4 sessions when certain thresholds are exceeded, some nuances in this specification were missing resulting in inconsistencies between BGP-4 implementations.
                 In addition to clarifying "inbound maximum prefix limits", this document also introduces a specification for "outbound maximum prefix limits".
             </t>
@@ -93,16 +93,16 @@
 
         <section title="Inbound Maximum Prefix Limits">
             <t>
-                An operator can configure a BGP speaker to terminate its BGP session with a neighbor when the number of address prefixes received from that neighbor exceeds a locally configured upper limit.
-                The BGP-4 speaker then MUST at a minimum be able to send to the neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Received", and optionally MAY support other actions.
-                Reporting when thresholds have been exceeded is implementation specific but SHOULD include methods such as Syslog <xref target="RFC5424"/>.
+                An operator MAY configure a BGP speaker to terminate its BGP session with a neighbor when the number of address prefixes received from that neighbor exceeds a locally configured upper limit.
+                The BGP speaker then MUST send the neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Received", and MAY support other actions.
+                Reporting when thresholds have been exceeded is an implementation specific consideration, but SHOULD include methods such as Syslog <xref target="RFC5424"/>.
                 Inbound Maximum Prefix Limits can be applied in two distinct places in the conceptual model: before or after the application of routing policy.
             </t>
             <section title="Type A: Pre-Policy Inbound Maximum Prefix Limits">
                 <t>
-                    Adj-RIB-In stores routing information learned from inbound UPDATE messages that were received from another BGP speaker <xref target="RFC4271">Section 3.2</xref>.
+                    The Adj-RIBs-In stores routing information learned from inbound UPDATE messages that were received from another BGP speaker <xref target="RFC4271">Section 3.2</xref>.
                     The Type A pre-policy limit uses the number of NLRIs per Address Family Identifier (AFI) per Subsequent Address Family Identifier (SAFI) as input into its threshold comparisons.
-                    As example, when an operator configures the Type A pre-policy limit for IPv4 Unicast to be 50 on a given EBGP session, and the other BGP speaker announces its 51th IPv4 Unicast NLRI, the session MUST be terminated.
+                    For example, when an operator configures the Type A pre-policy limit for IPv4 Unicast to be 50 on a given EBGP session, and the other BGP speaker announces its 51st IPv4 Unicast NLRI, the session MUST be terminated.
                 </t>
                 <t>
                     Type A pre-policy limits are particularly useful to help dampen the effects of full table route leaks and memory exhaustion when the implementation stores rejected routes.
@@ -112,7 +112,7 @@
                 <t>
                     RFC4271 describes a Policy Information Base (PIB) that contains local policies that can be applied to the information in the Routing Information Base (RIB).
                     The Type B post-policy limit uses the number of NLRIs per Address Family Identifier (AFI) per Subsequent Address Family Identifier (SAFI), after application of the Import Policy as input into its threshold comparisons.
-                    As an example, when an operator configures the Type B post-policy limit for IPv4 Unicast to be 50 on a given EBGP session, and the other BGP speaker announces a hundred IPv4 Unicast routes of which none are accepted due to local policy (and thus not considered for the Loc-RIB by the local BGP speaker), the session is not terminated.
+                    For example, when an operator configures the Type B post-policy limit for IPv4 Unicast to be 50 on a given EBGP session, and the other BGP speaker announces a hundred IPv4 Unicast routes of which none are accepted as a result of the local import policy (and thus not considered for the Loc-RIB by the local BGP speaker), the session is not terminated.
                 </t>
                 <t>
                     Type B post-policy limits are useful to help prevent FIB exhaustion.
@@ -122,17 +122,20 @@
 
         <section title="Outbound Maximum Prefix Limits">
             <t>
-                The Adj-RIBs-Out stores information the local BGP speaker selected for advertisement to its neighbors.
-                The routing information stored in the Adj-RIBs-Out will be carried in the local BGP speaker's UPDATE messages and advertised to its neighbors <xref target="RFC4271">Section 3.2</xref>.
-                The Outbound Maximum Prefix Limit uses the number NLRIs per Address Family Identifier (AFI) per Subsequent Address Family Identifier (SAFI), after application of the Export Policy as input into its threshold comparisons.
+                An operator MAY configure a BGP speaker to terminate its BGP session with a neighbor when the number of address prefixes to be advertised to that neighbor exceeds a locally configured upper limit.
+                The BGP speaker then MUST send the neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Sent", and MAY support other actions.
+                Reporting when thresholds have been exceeded is an implementation specific consideration, but SHOULD include methods such as Syslog <xref target="RFC5424"/>.
                 By definition, Outbound Maximum Prefix Limits are Post-Policy.
             </t>
             <t>
-                When an operator configures the Outbound Maximum Prefix Limit to be 50 on a given EBGP session, and for one reason or another the BGP speaker would advertise more than 50 routes, the BGP speaker MUST at a minimum be able to terminate the session and send its neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Sent", and MAY offer other actions such as appending to Syslog.
+                The Adj-RIBs-Out stores information selected by the local BGP speaker for advertisement to its neighbors.
+                The routing information stored in the Adj-RIBs-Out will be carried in the local BGP speaker's UPDATE messages and advertised to its neighbors <xref target="RFC4271">Section 3.2</xref>.
+                The Outbound Maximum Prefix Limit uses the number of NLRIs per Address Family Identifier (AFI) per Subsequent Address Family Identifier (SAFI), after application of the Export Policy, as input into its threshold comparisons.
+                For example, when an operator configures the Outbound Maximum Prefix Limit for IPv4 Unicast to be 50 on a given EBGP session, and were about to announce its 51st IPv4 Unicast NLRI to the other BGP speaker as a result of the local export policy, the session MUST be terminated.
             </t>
             <t>
                 Outbound Maximum Prefix Limits are useful to help dampen the negative effects of a misconfiguration in local policy.
-                In some cases it may be more desirable to tear down a BGP session rather than participate in a route leak.
+                In many cases, it would be more desirable to tear down a BGP session rather than causing or propagating a route leak.
             </t>
         </section>
 

--- a/draft-sa-grow-maxprefix.xml
+++ b/draft-sa-grow-maxprefix.xml
@@ -123,7 +123,7 @@
         <section title="Outbound Maximum Prefix Limits">
             <t>
                 An operator MAY configure a BGP speaker to terminate its BGP session with a neighbor when the number of address prefixes to be advertised to that neighbor exceeds a locally configured upper limit.
-                The BGP speaker then MUST send the neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Sent", and MAY support other actions.
+                The BGP speaker then MUST send the neighbor a NOTIFICATION message with the Error Code Cease and the Error Subcode "Threshold reached: Maximum Number of Prefixes Selected for Export by Policy", and MAY support other actions.
                 Reporting when thresholds have been exceeded is an implementation specific consideration, but SHOULD include methods such as Syslog <xref target="RFC5424"/>.
                 By definition, Outbound Maximum Prefix Limits are Post-Policy.
             </t>
@@ -162,7 +162,7 @@
                 This memo requests that IANA updates the name of subcode "Maximum Number of Prefixes Reached" to "Threshold exceeded: Maximum Number of Prefixes Received" in the "Cease NOTIFICATION message subcodes" registry under the "Border Gateway Protocol (BGP) Parameters" group.
             </t>
             <t>
-                This memo requests that IANA assigns a new subcode named "Threshold exceeded: Maximum Number of Prefixes Sent" in the "Cease NOTIFICATION message subcodes" registry under the "Border Gateway Protocol (BGP) Parameters" group.
+                This memo requests that IANA assigns a new subcode named "Threshold exceeded: Maximum Number of Prefixes Selected for Export by Policy" in the "Cease NOTIFICATION message subcodes" registry under the "Border Gateway Protocol (BGP) Parameters" group.
             </t>
         </section>
         <section title="Acknowledgments">


### PR DESCRIPTION
- various small grammar nits
- modified or into and/or in the abstract and introduction
- simplified the sentences describing NOTIFICATION message behaviour
- corrected Adj-RIB-In to Adj-RIBs-in as per RFC4271 section 3.2a
- As example|As an example -> For example
- 51th modified to 51st

Furthermore, I've suggested a rewording of the Outbound Maximum Prefix Limits section to more closely match the wording used in the earlier sections on Inbound Maximum Prefix Limits.

I'd also suggest using slightly stronger language in the description of the purpose of Outbound Maximum Prefix Limits.

Finally, maybe Error Subcode "Threshold reached: Maximum Number of Prefixes Selected for Export by Policy" would be a less confusing alternative?

One thing to clarify in the draft is that when the outbound limit is exceeded, you'd want to tear down the session BEFORE the NLRI is sent to the neighbor via the UPDATE message. Doing so afterwards causes unnecessary churn when the session is going to be ceased anyway. And as a famous man once said, it is good to be conservative in what you send. :)